### PR TITLE
Create a new service account for the ESP web apps

### DIFF
--- a/esp-cloud/clients/templates/clientserviceaccount/sas-esp-clients-binding.yaml
+++ b/esp-cloud/clients/templates/clientserviceaccount/sas-esp-clients-binding.yaml
@@ -1,0 +1,11 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: sas-esp-clients
+subjects:
+- kind: ServiceAccount
+  name: sas-esp-clients
+roleRef:
+  kind: Role
+  name: sas-esp-clients
+  apiGroup: rbac.authorization.k8s.io

--- a/esp-cloud/clients/templates/clientserviceaccount/sas-esp-clients-role.yaml
+++ b/esp-cloud/clients/templates/clientserviceaccount/sas-esp-clients-role.yaml
@@ -1,0 +1,38 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  name: sas-esp-clients
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - list
+  - watch
+
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
+
+- apiGroups:
+  - iot.sas.com
+  resources:
+  - espservers
+  - espconfigs
+  verbs:
+  - get
+  - list
+
+- apiGroups:
+  - iot.sas.com
+  resources:
+  - espservers
+  verbs:
+  - create
+  - watch
+  - delete

--- a/esp-cloud/clients/templates/clientserviceaccount/sas-esp-clients-serviceaccount.yaml
+++ b/esp-cloud/clients/templates/clientserviceaccount/sas-esp-clients-serviceaccount.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sas-esp-clients

--- a/esp-cloud/clients/templates/esm/esm.yml
+++ b/esp-cloud/clients/templates/esm/esm.yml
@@ -48,7 +48,7 @@ spec:
       labels:
         app: sas-event-stream-manager-app
     spec:
-      serviceAccountName: esp-operator
+      serviceAccountName: sas-esp-clients
       containers:
       - name: esm-container
         image: TEMPLATE_ESM_IMAGE

--- a/esp-cloud/clients/templates/espstudio/espstudio.yml
+++ b/esp-cloud/clients/templates/espstudio/espstudio.yml
@@ -48,7 +48,7 @@ spec:
       labels:
         app: sas-event-stream-processing-studio-app
     spec:
-      serviceAccountName: esp-operator
+      serviceAccountName: sas-esp-clients
       containers:
       - name: espstudio-container
         image: TEMPLATE_ESPSTUDIO_IMAGE

--- a/esp-cloud/clients/templates/streamviewer/streamviewer.yml
+++ b/esp-cloud/clients/templates/streamviewer/streamviewer.yml
@@ -48,7 +48,7 @@ spec:
       labels:
         app: sas-event-stream-processing-streamviewer-app
     spec:
-      serviceAccountName: esp-operator
+      serviceAccountName: sas-esp-clients
       containers:
       - name: streamviewer-container
         image: TEMPLATE_STREAMVIEWER_IMAGE


### PR DESCRIPTION
The web apps need to run with a service account with the permissions required to use the k8s API for CRUD operations with the ESPServer CR (along with some other operations). Previously we used the sas-esp-operator account but that grants extra permissions we don't need.

See ESPSTUDIO-4354 and ESPSTUDIO-4326